### PR TITLE
Travis CI, Netlify, Testing in general, fixes #17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 dist: trusty
 env:
   - DISABLE_CHROMIUM_SANDBOX=true
+addons:
+  chrome: stable
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - DISABLE_CHROMIUM_SANDBOX=true
 addons:
   chrome: stable
+sudo: required
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,11 @@ language: node_js
 node_js:
   - "8.9.4"
   - "9"
-dist: trusty
-env:
-  - DISABLE_CHROMIUM_SANDBOX=true
-addons:
-  chrome: stable
-sudo: required
 cache:
   directories:
     - node_modules
 script:
   - lerna bootstrap
   - npm test
+# https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
+sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,12 @@ language: node_js
 node_js:
   - "8.9.4"
   - "9"
-script: lerna bootstrap && npm test
+dist: trusty
+env:
+  - DISABLE_CHROMIUM_SANDBOX=true
+cache:
+  directories:
+    - node_modules
+script:
+  - lerna bootstrap
+  - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,27 +618,6 @@
 				"through2": "2.0.3"
 			}
 		},
-		"@unic/estatico-data": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/@unic/estatico-data/-/estatico-data-0.0.2.tgz",
-			"integrity": "sha512-l7KLjFVGL7GKi3nH1woNyHkMHzBTMHmr2QBW9qdcJlrHO0gDzddRWHgigdIHM4pTf44098lX/lcEzsK6hKXRDw==",
-			"requires": {
-				"callsite": "1.0.0",
-				"glob": "7.1.2",
-				"highlight.js": "9.12.0",
-				"marked": "0.3.12"
-			}
-		},
-		"@unic/estatico-qunit": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/@unic/estatico-qunit/-/estatico-qunit-0.0.2.tgz",
-			"integrity": "sha512-KUY9xvpluhjvoHKfOB/T+Y10ZvmCkbKI+mioLLTaPne8sdSO3Spj+HKnJbn+4e1zBNifreVzEfWssWLeX14/4w==",
-			"requires": {
-				"chalk": "2.3.0",
-				"fancy-log": "1.3.2",
-				"qunitjs": "2.4.1"
-			}
-		},
 		"JSONStream": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -19594,14 +19573,14 @@
 			}
 		},
 		"webpack": {
-			"version": "4.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.0.0-beta.0.tgz",
-			"integrity": "sha512-5xoeywLiMS9aZZkauREImWoSc3pui9NLWsnYljgy3mm5BT+qPk8zBS6M188Be12fii/++F3PJBsXlrobNPRb7w==",
+			"version": "4.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.0.0-beta.1.tgz",
+			"integrity": "sha512-+Qghq7TiXoDRXFmdZ5jJ/jRx6ruQnVUh3ecy59en6/zcssB0t75UWkPXsPeOXNC8WoCiQLcCqu0cobKcgSanKA==",
 			"requires": {
 				"acorn": "5.3.0",
 				"acorn-dynamic-import": "3.0.0",
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
+				"ajv": "6.1.1",
+				"ajv-keywords": "3.1.0",
 				"async": "2.6.0",
 				"chrome-trace-event": "0.1.1",
 				"enhanced-resolve": "4.0.0-beta.4",
@@ -19618,6 +19597,21 @@
 				"webpack-sources": "1.1.0"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+					"integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+					"requires": {
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+					"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
+				},
 				"async": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "lint": "eslint --fix \"{,**,**/**}*.js\"",
     "update-dependencies": "npx npm-check-updates -u -a",
-    "test": "lerna exec -- npm test"
+    "test": "lerna exec -- npm test",
+    "netlify": "lerna bootstrap && lerna exec --scope @unic/estatico-boilerplate -- npm run gulp build -- --skipTests"
   }
 }

--- a/packages/estatico-boilerplate/package.json
+++ b/packages/estatico-boilerplate/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests specified\"",
+    "test": "gulp build --noInteractive",
     "gulp": "gulp"
   },
   "author": "Unic AG",

--- a/packages/estatico-browsersync/package.json
+++ b/packages/estatico-browsersync/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"@unic/estatico-browsersync: No tests specified\""
   },
   "author": "Unic AG",
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-browsersync",

--- a/packages/estatico-data/package.json
+++ b/packages/estatico-data/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"@unic/estatico-data: No tests specified\""
   },
   "author": "Unic AG",
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-data",

--- a/packages/estatico-qunit/package.json
+++ b/packages/estatico-qunit/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"@unic/estatico-qunit: No tests specified\""
   },
   "author": "Unic AG",
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-qunit",

--- a/packages/estatico-utils/package.json
+++ b/packages/estatico-utils/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"@unic/estatico-utils: No tests specified\""
   },
   "author": "Unic AG",
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-utils",

--- a/packages/estatico-watch/package.json
+++ b/packages/estatico-watch/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests specified\""
+    "test": "echo \"@unic/estatico-watch: No tests specified\""
   },
   "author": "Unic AG",
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-watch",

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -26,7 +26,7 @@
     "style-loader": "^0.20.1",
     "uglifyjs-webpack-plugin": "^1.1.8",
     "unminified-webpack-plugin": "github:unic/unminified-webpack-plugin#18bfc8dfafeeb9f025d0a394819ae7c556e2a734",
-    "webpack": "^4.0.0-beta.0",
+    "webpack": "^4.0.0-beta.1",
     "webpack-bundle-analyzer": "^2.9.2",
     "webpack-modernizr-loader": "^4.0.0"
   },

--- a/packages/estatico-webpack/test/expected/dev/main.js
+++ b/packages/estatico-webpack/test/expected/dev/main.js
@@ -79,7 +79,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\n\nObject.defineProperty(exports, \"__esModule\", {\n  value: true\n});\nexports.default = void 0;\nvar _default = 'hello';\nexports.default = _default;\n\n//////////////////\n// WEBPACK FOOTER\n// ./test/fixtures/bar.js\n// module id = ./test/fixtures/bar.js\n// module chunks = main\n\n//# sourceURL=webpack:///./test/fixtures/bar.js?");
+eval("\n\nObject.defineProperty(exports, \"__esModule\", {\n  value: true\n});\nexports.default = void 0;\nvar _default = 'hello';\nexports.default = _default;\n\n//# sourceURL=webpack:///./test/fixtures/bar.js?");
 
 /***/ }),
 
@@ -91,7 +91,7 @@ eval("\n\nObject.defineProperty(exports, \"__esModule\", {\n  value: true\n});\n
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\n\nvar _bar = _interopRequireDefault(__webpack_require__(/*! ./bar */ \"./test/fixtures/bar.js\"));\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nconsole.log(_bar.default);\n\n//////////////////\n// WEBPACK FOOTER\n// ./test/fixtures/main.js\n// module id = ./test/fixtures/main.js\n// module chunks = main\n\n//# sourceURL=webpack:///./test/fixtures/main.js?");
+eval("\n\nvar _bar = _interopRequireDefault(__webpack_require__(/*! ./bar */ \"./test/fixtures/bar.js\"));\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nconsole.log(_bar.default);\n\n//# sourceURL=webpack:///./test/fixtures/main.js?");
 
 /***/ })
 


### PR DESCRIPTION
- Fixed Travis CI config since it currently doesn't start headless Chrome unless `sudo: required` is set. While https://github.com/travis-ci/travis-ci/issues/8836 states this was fixed, it doesn't seem to work.
- Updated to latest Webpack beta, changed test files accordingly. This was necessary since Travis used `4.0.0-beta.1` over the local `4.0.0-beta.0`, breaking tests.
- Improved logging on inexistent tests to show the package's name (from `Error: No tests specified` to `@unic/estatico-qunit: No tests specified`, e.g).
- Changed boilerplate test script to just create complete build. This isn't very sophisticated, but it would still catch breaking issues.
- Added Netlify integration. As a part of this, the `build` task in the boilerplate received a prompt / env flag to skip tests and linting. Since Travis will already take care of this, there is no need to run it on Netlify.