### PR TITLE
Refactored logging to use gulplog, simplifying debugging

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -387,13 +387,13 @@ gulp.task('js:test', () => {
       },
     },
     plugins: {
-      interact: async (page) => {
+      interact: async (page, logger) => {
         // Run tests
         const results = await estaticoQunit.puppeteer.run(page);
 
         // Report results
         if (results) {
-          estaticoQunit.puppeteer.log(results);
+          estaticoQunit.puppeteer.log(results, logger);
         }
       },
     },

--- a/packages/estatico-eslint/README.md
+++ b/packages/estatico-eslint/README.md
@@ -44,6 +44,8 @@ gulp.task('js:lint', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp js:lint`
 
+See possible flags specified above.
+
 ## API
 
 `plugin(options, env)` => `taskFn`

--- a/packages/estatico-eslint/index.js
+++ b/packages/estatico-eslint/index.js
@@ -85,7 +85,7 @@ const task = (config, env = {}) => {
 
         // Only keep file in stream if it was fixed
         if (file.eslint.fixed) {
-          config.logger.info(`Fixed linting issues in ${chalk.yellow(relFilePath)}`);
+          config.logger.info(`Automatically fixed linting issues in ${chalk.yellow(relFilePath)}. Set "plugins.eslint.fix" to false to disable this functionality.`);
 
           return done(null, file);
         }

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -20,6 +20,7 @@ const env = require('minimist')(process.argv.slice(2));
  * Transforms Handlebars to HTML
  *
  * Using `--watch` (or manually setting `env` to `{ dev: true }`) starts file watcher
+ * Using `-LLLL` will display debug info like the data used for every template
  */
 gulp.task('html', () => {
   const task = require('@unic/estatico-handlebars');
@@ -122,11 +123,7 @@ gulp.task('html', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp html`
 
-Run with debug info (showing you which file is passed through which step, e.g.):
-`$ NODE_DEBUG=estatico-handlebars npm run gulp html`
-
-Run with extended debug info (showing you the data used for every template, e.g.):
-`$ NODE_DEBUG=estatico-handlebars-extended npm run gulp html`
+See possible flags specified above.
 
 
 ## API

--- a/packages/estatico-handlebars/index.js
+++ b/packages/estatico-handlebars/index.js
@@ -64,7 +64,7 @@ const defaults = env => ({
       const dataFilePath = file.path.replace(path.extname(file.path), '.data.js');
 
       if (!fs.existsSync(dataFilePath)) {
-        logger.debug('data', `Data file ${chalk.yellow(dataFilePath)} not found for ${chalk.yellow(file.path)}. This will not break anything, but the template will receive no data.`);
+        logger.debug(`Data file ${chalk.yellow(dataFilePath)} not found for ${chalk.yellow(file.path)}. This will not break anything, but the template will receive no data.`);
       }
 
       const data = require(dataFilePath); // eslint-disable-line
@@ -158,10 +158,10 @@ const task = (config, env = {}, watcher) => {
         const resolvedGraph = watcher.resolvedGraph.map(getSimplifiedFilePath);
         const simplifiedFilePath = getSimplifiedFilePath(file.path);
 
-        config.logger.debug('watcher', 'Resolved watch graph:', watcher.resolvedGraph);
+        config.logger.debug('Resolved watch graph:', watcher.resolvedGraph);
 
         if (!resolvedGraph.includes(simplifiedFilePath)) {
-          config.logger.debug('watcher', `${chalk.yellow(simplifiedFilePath)} not found in resolved graph. It will not be rebuilt.`);
+          config.logger.debug(`${chalk.yellow(simplifiedFilePath)} not found in resolved graph. It will not be rebuilt.`);
 
           return done();
         }
@@ -177,7 +177,7 @@ const task = (config, env = {}, watcher) => {
 
         file.contents = content; // eslint-disable-line no-param-reassign
 
-        config.logger.debug('transformBefore', `Transformed ${chalk.yellow(file.path)}`, chalk.gray(content.toString()), true);
+        config.logger.debug(`Transformed ${chalk.yellow(file.path)} via "transformBefore"` /* , chalk.gray(content.toString()) */);
       }
 
       done(null, file);
@@ -190,7 +190,7 @@ const task = (config, env = {}, watcher) => {
 
         file.data = data; // eslint-disable-line no-param-reassign
 
-        config.logger.debug('data', `Data found for ${chalk.yellow(file.path)}`, chalk.gray(JSON.stringify(data, null, '\t')), true);
+        config.logger.debug(`Data found for ${chalk.yellow(file.path)}`, chalk.gray(JSON.stringify(data, null, '\t')));
 
         done(null, file);
       } catch (err) {
@@ -213,7 +213,7 @@ const task = (config, env = {}, watcher) => {
           clone.path = config.plugins.clone.rename(file.path);
         }
 
-        config.logger.debug('clone', `Cloned ${chalk.yellow(file.path)} to ${chalk.yellow(clone.path)}`);
+        config.logger.debug(`Cloned ${chalk.yellow(file.path)} to ${chalk.yellow(clone.path)}`);
 
         this.push(clone);
       }
@@ -231,7 +231,7 @@ const task = (config, env = {}, watcher) => {
 
         file.contents = content; // eslint-disable-line
 
-        config.logger.debug('transformAfter', `Transformed ${chalk.yellow(file.path)}`);
+        config.logger.debug(`Transformed ${chalk.yellow(file.path)} via "transformAfter"`);
       }
 
       done(null, file);
@@ -244,9 +244,9 @@ const task = (config, env = {}, watcher) => {
     .pipe(through.obj((file, enc, done) => {
       const renamedPath = file.path.replace(path.extname(file.path), '.html');
 
-      config.logger.debug('rename', `Renaming ${file.path} to ${chalk.yellow(renamedPath)}`);
-
       file.path = renamedPath; // eslint-disable-line no-param-reassign
+
+      config.logger.debug(`Renamed ${chalk.yellow(file.path)} to ${chalk.yellow(renamedPath)}`);
 
       done(null, file);
     }))

--- a/packages/estatico-puppeteer/README.md
+++ b/packages/estatico-puppeteer/README.md
@@ -71,6 +71,8 @@ gulp.task('js:test', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp js:test`
 
+See possible flags specified above.
+
 ## API
 
 `plugin(options, env)` => `taskFn`

--- a/packages/estatico-puppeteer/index.js
+++ b/packages/estatico-puppeteer/index.js
@@ -34,7 +34,7 @@ const defaults = (/* env */) => ({
   plugins: {
     puppeteer: {
     },
-    // interact: async (page) => {
+    // interact: async (page, logger) => {
     // },
   },
   logger: new Logger('estatico-puppeteer'),
@@ -94,10 +94,10 @@ const task = (config, env = {}) => {
               config.logger.info(`Testing viewport ${chalk.yellow(viewport)}`);
 
               await page.setViewport(config.viewports[viewport]);
-              await config.plugins.interact(page);
+              await config.plugins.interact(page, config.logger);
             }
           } else {
-            await config.plugins.interact(page);
+            await config.plugins.interact(page, config.logger);
           }
         } catch (err) {
           error = err;

--- a/packages/estatico-qunit/lib/puppeteer.js
+++ b/packages/estatico-qunit/lib/puppeteer.js
@@ -1,5 +1,4 @@
 /* globals QUnit */
-const log = require('fancy-log');
 const chalk = require('chalk');
 
 module.exports = {
@@ -37,15 +36,15 @@ module.exports = {
 
     return results;
   },
-  log: (results) => {
+  log: (results, logger) => {
     results.details.forEach((test) => {
       if (test.failed === 0) {
-        log(chalk.green(`✓ ${test.name}`));
+        logger.info(chalk.green(`✓ ${test.name}`));
       } else {
-        log(chalk.red(`× ${test.name}`));
+        logger.info(chalk.red(`× ${test.name}`));
 
         test.assertions.filter(assertion => !assertion.result).forEach((assertion) => {
-          log(chalk.red(`Failing assertion: ${assertion.message}`));
+          logger.info(chalk.red(`Failing assertion: ${assertion.message}`));
         });
       }
     });

--- a/packages/estatico-qunit/package.json
+++ b/packages/estatico-qunit/package.json
@@ -11,7 +11,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^2.3.0",
-    "fancy-log": "^1.3.0",
     "qunitjs": "^2.4.1"
   },
   "engines": {

--- a/packages/estatico-sass/README.md
+++ b/packages/estatico-sass/README.md
@@ -20,6 +20,7 @@ const env = require('minimist')(process.argv.slice(2));
  *
  * Using `--dev` (or manually setting `env` to `{ dev: true }`) skips minification
  * Using `--watch` (or manually setting `env` to `{ dev: true }`) starts file watcher
+ * Using `-LLLL` will display debug info like detailed autoprefixer configs
  */
 gulp.task('css', () => {
   const task = require('@unic/estatico-sass');
@@ -91,7 +92,7 @@ gulp.task('css', () => {
       postcss: [
         autoprefixer({
           // Custom autoprefixer config
-          browsers: ['last 10 versions'],
+          browsers: ['last 2 versions'],
         }),
       ],
     },
@@ -104,8 +105,7 @@ gulp.task('css', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp css`
 
-Run with debug info (showing you the autoprefixer setup, e.g.):
-`$ NODE_DEBUG=estatico-sass npm run gulp css`
+See possible flags specified above.
 
 ## API
 

--- a/packages/estatico-sass/index.js
+++ b/packages/estatico-sass/index.js
@@ -93,10 +93,10 @@ const task = (config, env = {}, watcher) => {
     // Decide based on watcher dependency graph which files to pass through
     .pipe(through.obj((file, enc, done) => {
       if (watcher && watcher.resolvedGraph) {
-        config.logger.debug('watcher', 'Resolved watch graph:', watcher.resolvedGraph);
+        config.logger.debug('Resolved watch graph:', watcher.resolvedGraph);
 
         if (!watcher.resolvedGraph.includes(file.path)) {
-          config.logger.debug('watcher', `${chalk.yellow(file.path)} not found in resolved graph. It will not be rebuilt.`);
+          config.logger.debug(`${chalk.yellow(file.path)} not found in resolved graph. It will not be rebuilt.`);
 
           return done();
         }
@@ -117,7 +117,7 @@ const task = (config, env = {}, watcher) => {
 
         clone.path = file.path.replace(path.extname(file.path), ext => `${config.minifiedSuffix}${ext}`);
 
-        config.logger.debug('clone', `Cloned ${chalk.yellow(file.path)} to ${chalk.yellow(clone.path)}`);
+        config.logger.debug(`Cloned ${chalk.yellow(file.path)} to ${chalk.yellow(clone.path)} to keep unminified files`);
 
         this.push(clone);
       }

--- a/packages/estatico-stylelint/README.md
+++ b/packages/estatico-stylelint/README.md
@@ -44,6 +44,8 @@ gulp.task('css:lint', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp css:lint`
 
+See possible flags specified above.
+
 ## API
 
 `plugin(options, env)` => `taskFn`

--- a/packages/estatico-svgsprite/README.md
+++ b/packages/estatico-svgsprite/README.md
@@ -39,6 +39,8 @@ gulp.task('svgsprite', () => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp svgsprite`
 
+See possible flags specified above.
+
 ### Client
 
 ```js

--- a/packages/estatico-utils/README.md
+++ b/packages/estatico-utils/README.md
@@ -22,17 +22,13 @@ const env = parseArgs(process.argv.slice(2));
 const logger = new Logger('estatico-bla');
 
 // Log info
-logger.info('Step X', 'Something is happening');
+logger.info('Something is happening');
 
-// Log debug info, only logged if "NODE_DEBUG=estatico-bla" is set
-// See https://nodejs.org/api/util.html#util_util_debuglog_section
-logger.debug('Step X', 'Something is happening');
-
-// Log "extended" debug info, only logged if "NODE_DEBUG=estatico-bla-extended" is set
-logger.debug('Step X', 'Something is happening', { /* Additional log info */ });
+// Log debug info, only logged if "-LLLL" is set
+logger.debug('Something is happening', /* Additional log info */);
 
 // Log error, will exit process unless env.dev is true
-logger.error('Step X', new Error('Something went wrong'), env.dev);
+logger.error(new Error('Something went wrong'), env.dev);
 ```
 
 ### Plugin

--- a/packages/estatico-utils/lib/logger.js
+++ b/packages/estatico-utils/lib/logger.js
@@ -1,55 +1,37 @@
 /* eslint-disable global-require */
 function Logger(pluginName) {
-  const util = require('util');
   const chalk = require('chalk');
-  const log = require('fancy-log');
-
-  const debugLogger = util.debuglog(pluginName);
-  const debugLoggerExtended = util.debuglog(`${pluginName}-extended`);
+  const fancyLog = require('fancy-log');
+  const log = require('gulplog');
 
   /**
    * Simple info logger
    * @param {*} msg - Log content
    */
   const info = (msg) => {
-    log(chalk.blue(pluginName), msg);
+    log.info(chalk.cyan(pluginName), msg);
   };
 
   /**
    * Debug logger
-   * @param {string} step - Title of current task step, will be highlighted
    * @param {*} msg - Log content
-   * @param {*} [extendedMsg] - Extended log content, will only be logged
-   * if `NODE_DEBUG=${pluginName}-extended` is set.
-   * The current Node version (9.5.0 at the time of writing) seems to support wildcards
-   * for sections, so `NODE_DEBUG=${pluginName}*` should be fine at some point, too.
+   * @param {*} [extendedMsg] - Extended log content
    */
-  const debug = (step, msg, extendedMsg) => {
-    // Highlight step
-    const label = chalk.yellowBright(step);
-
-    // Simple message (if env variable `NODE_DEBUG=${pluginName}` is set)
-    debugLogger(label, msg);
-
-    // Extended message (if env variable `NODE_DEBUG=${pluginName}-extended` is set)
-    // TODO: Find a way of not logging twice
-    if (extendedMsg) {
-      debugLoggerExtended(label, msg, `\n${extendedMsg}`);
-    }
+  const debug = (msg, extendedMsg) => {
+    log.debug(chalk.cyan(pluginName), msg, extendedMsg ? `\n${extendedMsg}` : '');
   };
 
   /**
    * Error logger
-   * @param {string} step - Title of current task step, will be highlighted
    * @param {Error} err
    * @param {boolean} [dev] - Whether we are in dev mode. Process exits otherwise.
    */
   const error = (err, dev) => {
-    log(chalk.blue(pluginName), err.fileName ? chalk.yellow(err.fileName) : '', chalk.red(err.message));
+    const stack = err.stack && err.showStack ? `\n${chalk.red(err.stack)}` : '';
 
-    if (err.stack) {
-      debugLogger(chalk.red(pluginName), err.stack);
-    }
+    // We cannot properly use `gulplog.error` outside of `gulp-cli` (i.e. in tests)
+    // Falling back to fancy-log instead
+    fancyLog(chalk.cyan(pluginName), err.fileName ? chalk.yellow(err.fileName) : '', chalk.red(err.message), stack);
 
     if (!dev) {
       process.exit(1);

--- a/packages/estatico-utils/package.json
+++ b/packages/estatico-utils/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@unic/estatico-watch": "0.0.4",
     "chalk": "^2.3.0",
-    "fancy-log": "^1.3.0",
+    "fancy-log": "^1.3.2",
+    "gulplog": "^1.0.0",
     "joi": "^13.1.2",
     "lodash.merge": "^4.6.0"
   },

--- a/packages/estatico-w3c-validator/README.md
+++ b/packages/estatico-w3c-validator/README.md
@@ -45,7 +45,9 @@ gulp.task('html:validate', () => {
 ```
 
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
-`$ npm run gulp htmlValidate`
+`$ npm run gulp html:validate`
+
+See possible flags specified above.
 
 ## API
 

--- a/packages/estatico-w3c-validator/test/index.js
+++ b/packages/estatico-w3c-validator/test/index.js
@@ -21,7 +21,7 @@ test.cb('default', (t) => {
 
     const log = utils.stripLogs(spy);
 
-    t.regex(log, /HTML Error: index.html Line 9, Column 15: End tag “h3” seen, but there were open elements./);
+    t.regex(log, /index\.html Linting error \(details above\)/);
 
     t.end();
   });

--- a/packages/estatico-watch/index.js
+++ b/packages/estatico-watch/index.js
@@ -56,6 +56,7 @@ const task = (config /* , env = {} */) => {
   if (config.dependencyGraph) {
     dependencyGraph = new DependencyGraph(Object.assign({
       paths: config.src,
+      logger: config.logger,
     }, config.dependencyGraph));
   }
 
@@ -80,7 +81,7 @@ const task = (config /* , env = {} */) => {
         resolvedGraph,
       });
 
-      config.logger.debug(config.name, `Resolving the following events: ${events}`);
+      config.logger.debug(`Resolving the following events for "${config.name}": ${events}`);
 
       // Reset events
       events = [];

--- a/packages/estatico-watch/lib/dependencygraph.js
+++ b/packages/estatico-watch/lib/dependencygraph.js
@@ -1,8 +1,7 @@
 const glob = require('glob');
 const fs = require('fs');
 const path = require('path');
-const log = require('fancy-log');
-// const chalk = require('chalk');
+const chalk = require('chalk');
 const graphlib = require('graphlib');
 
 const Graph = graphlib.Graph; // eslint-disable-line prefer-destructuring
@@ -16,7 +15,7 @@ class DependencyGraph {
     this.options = Object.assign({
       paths: [],
       resolver: {},
-      log: false,
+      logger: null,
     }, options);
 
     this.graph = new Graph();
@@ -42,8 +41,8 @@ class DependencyGraph {
 
     // Skip missing resolvers
     if (!resolver) {
-      if (this.options.log) {
-        log('DependencyGraph', `Resolver '${path.extname(filePath)}' not found`);
+      if (this.options.logger) {
+        this.options.logger.debug(`Dependency graph: Resolver '${path.extname(filePath)}' not found`);
       }
 
       return [];
@@ -51,8 +50,8 @@ class DependencyGraph {
 
     // Skip missing files
     if (!content) {
-      if (this.options.log) {
-        log('DependencyGraph', `'${filePath}' not found`);
+      if (this.options.logger) {
+        this.options.logger.debug(`Dependency graph: ${chalk.yellow(filePath)} not found`);
       }
 
       return [];
@@ -76,8 +75,8 @@ class DependencyGraph {
 
       if (matchedFilePath) {
         matches.push(matchedFilePath);
-      } else {
-        log('DependencyGraph', `'${match[0]}' not found`);
+      } else if (this.options.logger) {
+        this.options.logger.debug(`Dependency graph: ${chalk.yellow(match[0])} not found`);
       }
     }
 

--- a/packages/estatico-watch/package.json
+++ b/packages/estatico-watch/package.json
@@ -13,7 +13,6 @@
     "@unic/estatico-utils": "0.0.4",
     "chalk": "^2.3.0",
     "decache": "^4.3.0",
-    "fancy-log": "^1.3.2",
     "glob": "^7.1.2",
     "graphlib": "^2.1.5",
     "lodash.merge": "^4.6.0"

--- a/packages/estatico-webpack/README.md
+++ b/packages/estatico-webpack/README.md
@@ -92,8 +92,7 @@ gulp.task('js', (cb) => {
 Run task (assuming the project's `package.json` specifies `"scripts": { "gulp": "gulp" }`):
 `$ npm run gulp js`
 
-Run with debug info:
-`$ NODE_DEBUG=estatico-webpack npm run gulp js`
+See possible flags specified above.
 
 ### Options
 

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -19,7 +19,6 @@
     "chalk": "^2.3.0",
     "css-loader": "^0.28.9",
     "expose-loader": "^0.7.4",
-    "fancy-log": "^1.3.0",
     "handlebars-loader": "github:unic/handlebars-loader",
     "lodash.merge": "^4.6.0",
     "lodash.once": "^4.1.1",


### PR DESCRIPTION
This change allows us to simply use `npm run gulp html -- -LLLL` over `NODE_DEBUG=estatico-handlebars-extended npm run gulp html`to log debugging info.