### PR TITLE
Start webpack if build is skipped but watch enabled

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -498,7 +498,12 @@ gulp.task('default', (done) => {
 
   const cb = (skipBuild) => {
     if (skipBuild) {
-      gulp.series('serve')(done);
+      if (env.watch) {
+        // Webpack tasks need to run to be able to start watcher
+        gulp.series('js', 'serve')(done);
+      } else {
+        gulp.series('serve')(done);
+      }
     } else {
       gulp.series('build', 'serve')(done);
     }

--- a/packages/estatico-webpack/index.js
+++ b/packages/estatico-webpack/index.js
@@ -123,7 +123,7 @@ const task = (config, env = {}, cb) => {
     const callback = (err, stats) => {
       let done = cb;
 
-      if (config.watch) {
+      if (env.watch) {
         done = once(done);
       }
 


### PR DESCRIPTION
This fixes an issue where using `--watch` but skipping the build prevented webpack from ever running .