### PR TITLE
Changed Node engine version to be less restrictive

### DIFF
--- a/packages/estatico-boilerplate/package.json
+++ b/packages/estatico-boilerplate/package.json
@@ -41,7 +41,7 @@
     "skip-link-focus": "^1.0.0"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-browsersync/package.json
+++ b/packages/estatico-browsersync/package.json
@@ -15,7 +15,7 @@
     "joi": "^13.1.2"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-eslint/package.json
+++ b/packages/estatico-eslint/package.json
@@ -22,7 +22,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-font-datauri/package.json
+++ b/packages/estatico-font-datauri/package.json
@@ -24,7 +24,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-handlebars/package.json
+++ b/packages/estatico-handlebars/package.json
@@ -25,7 +25,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-puppeteer/package.json
+++ b/packages/estatico-puppeteer/package.json
@@ -18,7 +18,7 @@
     "puppeteer": "^1.0.0"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-qunit/package.json
+++ b/packages/estatico-qunit/package.json
@@ -14,7 +14,7 @@
     "qunitjs": "^2.4.1"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-sass/package.json
+++ b/packages/estatico-sass/package.json
@@ -28,7 +28,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-stylelint/package.json
+++ b/packages/estatico-stylelint/package.json
@@ -21,7 +21,7 @@
     "stylelint": "^8.4.0"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-svgsprite/package.json
+++ b/packages/estatico-svgsprite/package.json
@@ -24,7 +24,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-w3c-validator/package.json
+++ b/packages/estatico-w3c-validator/package.json
@@ -22,7 +22,7 @@
     "through2": "^2.0.3"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -30,7 +30,7 @@
     "webpack-modernizr-loader": "^4.0.0"
   },
   "engines": {
-    "node": ">=8 <9"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We are building on Node 9 anyway, so let's allow it in each modules `package.json`.