### PR TITLE
[WIP] estatico-handlebars: Optimize rebuild behavior

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -4,6 +4,10 @@ const path = require('path');
 const fs = require('fs');
 const env = require('minimist')(process.argv.slice(2));
 
+env.browserSync = {
+  currentUrl: '',
+};
+
 
 /**
  * HTML task
@@ -16,6 +20,7 @@ gulp.task('html', () => {
   const task = require('@unic/estatico-handlebars');
   const estaticoQunit = require('@unic/estatico-qunit');
   const { readFileSyncCached } = require('@unic/estatico-utils');
+  const { parse } = require('url');
 
   const instance = task({
     src: [
@@ -101,6 +106,16 @@ gulp.task('html', () => {
         content = Buffer.from(content);
 
         return content;
+      },
+      sort: (file) => {
+        const currentPath = parse(env.browserSync.currentUrl).pathname || '';
+        const filePath = path.relative('./src', file.path).replace(path.extname(file.path), '');
+
+        if (currentPath.includes(filePath)) {
+          return -1;
+        }
+
+        return 1;
       },
     },
   }, env);
@@ -575,12 +590,37 @@ gulp.task('serve', () => {
     plugins: {
       browsersync: {
         server: './dist',
-        watch: './dist/**/*.{html,css,js}',
+        files: [
+          './dist/**/*.{css,js}',
+          {
+            match: ['./dist/**/*.html'],
+            // Reload only if current url is affected
+            fn: function fn(event, file) {
+              const filePath = path.relative('./dist', file);
+
+              if (env.browserSync.currentUrl && !env.browserSync.currentUrl.includes(filePath)) {
+                return;
+              }
+
+              this.reload();
+            },
+          },
+        ],
       },
     },
   }, env);
 
-  return instance();
+  const browserSync = instance();
+
+  // Save last requested url
+  // This can be used to decide with html page to build first
+  browserSync.emitter.on('service:running', () => {
+    browserSync.sockets.on('connection', (socket) => {
+      env.browserSync.currentUrl = socket.handshake.headers.referer;
+    });
+  });
+
+  return browserSync;
 });
 
 /**

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -107,6 +107,7 @@ gulp.task('html', () => {
 
         return content;
       },
+      // Prioritize the currently active page (as reported by BrowserSync)
       sort: (file) => {
         const currentPath = parse(env.browserSync.currentUrl).pathname || '';
         const filePath = path.relative('./src', file.path).replace(path.extname(file.path), '');
@@ -613,7 +614,7 @@ gulp.task('serve', () => {
   const browserSync = instance();
 
   // Save last requested url
-  // This can be used to decide with html page to build first
+  // This can be used to decide which html page to build first
   browserSync.emitter.on('service:running', () => {
     browserSync.sockets.on('connection', (socket) => {
       env.browserSync.currentUrl = socket.handshake.headers.referer;

--- a/packages/estatico-browsersync/index.js
+++ b/packages/estatico-browsersync/index.js
@@ -7,7 +7,7 @@ const schema = Joi.object().keys({
   plugins: {
     browsersync: Joi.object().keys({
       server: Joi.string().required(),
-      watch: Joi.string().allow(null),
+      watch: [Joi.string().allow(null), Joi.array().allow(null)],
       port: Joi.number().required(),
       middleware: Joi.func().allow(null),
     }),
@@ -64,7 +64,9 @@ const task = (config /* , env = {} */) => {
 
   const bs = browsersync.create();
 
-  return bs.init(config.plugins.browsersync);
+  bs.init(config.plugins.browsersync);
+
+  return bs;
 };
 
 /**

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -250,14 +250,25 @@ Passed to [`gulp-prettify`](https://www.npmjs.com/package/gulp-prettify). Settin
 Type: `Object`<br>
 Default:
 ```js
-clone: dev ? null : {
-  data: {
+clone: env.ci ? (file) => {
+  const path = require('path');
+  const merge = require('lodash.merge');
+
+  const clone = file.clone();
+
+  // Extend default data
+  clone.data = merge({}, file.data, {
     env: {
-      dev: false,
+      dev: true,
     },
-  },
-  rename: filePath => filePath.replace(path.extname(filePath), `.prod${path.extname(filePath)}`),
-},
+  });
+
+  // Rename
+  clone.path = file.path.replace(path.extname(file.path), `.dev${path.extname(file.path)}`);
+
+  // Return array
+  return [clone];
+} : null,
 ```
 
 This potentially speeds up CI builds (where the same templates are built with both a dev and prod config) since we only run the expensive task of setting up the data once.

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -275,6 +275,26 @@ This potentially speeds up CI builds (where the same templates are built with bo
 
 The CI needs to take care of moving & renaming the `.prod.html` files.
 
+#### plugins.sort
+
+Type: `Function`<br>
+Default: `null`
+
+Example:
+```js
+// Prioritize the currently active page (as reported by BrowserSync)
+sort: (file) => {
+  const currentPath = parse(env.browserSync.currentUrl).pathname || '';
+  const filePath = path.relative('./src', file.path).replace(path.extname(file.path), '');
+
+  if (currentPath.includes(filePath)) {
+    return -1;
+  }
+
+  return 1;
+},
+```
+
 #### logger
 
 Type: `{ info: Function, debug: Function, error: Function }`<br>

--- a/packages/estatico-handlebars/index.js
+++ b/packages/estatico-handlebars/index.js
@@ -315,7 +315,7 @@ const task = (config, env = {}, watcher) => {
       if (!stream.continue) {
         stream.continue = true;
       }
-      console.log(file.path);
+
       return done(null, file);
     }));
 };

--- a/packages/estatico-handlebars/test/index.js
+++ b/packages/estatico-handlebars/test/index.js
@@ -24,7 +24,7 @@ const defaults = {
 };
 
 test.cb('default', (t) => {
-  task(defaults)().on('end', () => utils.compareFiles(t, path.join(__dirname, 'expected/default/*')));
+  task(defaults)().on('finish', () => utils.compareFiles(t, path.join(__dirname, 'expected/default/*')));
 });
 
 test.cb('unprettified', (t) => {
@@ -34,7 +34,7 @@ test.cb('unprettified', (t) => {
     },
   });
 
-  task(options)().on('end', () => utils.compareFiles(t, path.join(__dirname, 'expected/unprettified/*')));
+  task(options)().on('finish', () => utils.compareFiles(t, path.join(__dirname, 'expected/unprettified/*')));
 });
 
 test.cb('customHelpers', (t) => {
@@ -49,7 +49,7 @@ test.cb('customHelpers', (t) => {
     },
   });
 
-  task(options)().on('end', () => utils.compareFiles(t, path.join(__dirname, 'expected/customHelpers/*')));
+  task(options)().on('finish', () => utils.compareFiles(t, path.join(__dirname, 'expected/customHelpers/*')));
 });
 
 test.cb('customHelpersFactory', (t) => {
@@ -68,7 +68,7 @@ test.cb('customHelpersFactory', (t) => {
     },
   });
 
-  task(options)().on('end', () => utils.compareFiles(t, path.join(__dirname, 'expected/customHelpers/*')));
+  task(options)().on('finish', () => utils.compareFiles(t, path.join(__dirname, 'expected/customHelpers/*')));
 });
 
 test.cb('error', (t) => {
@@ -80,7 +80,7 @@ test.cb('error', (t) => {
 
   task(options, {
     dev: true,
-  })().on('end', () => {
+  })().on('finish', () => {
     spy.restore();
 
     const log = utils.stripLogs(spy);

--- a/packages/estatico-webpack/index.js
+++ b/packages/estatico-webpack/index.js
@@ -2,6 +2,9 @@
 const { Plugin, Logger } = require('@unic/estatico-utils');
 const Joi = require('joi');
 
+// We export webpack to allow for complete flexibility in config overwrite
+const webpack = require('webpack');
+
 // Config schema used for validation
 const schema = Joi.object().keys({
   webpack: [Joi.object(), Joi.array()],
@@ -115,7 +118,6 @@ const defaults = (env) => {
  * @return {object} gulp stream
  */
 const task = (config, env = {}, cb) => {
-  const webpack = require('webpack');
   const once = require('lodash.once');
   const { format } = require('./lib/stats');
 
@@ -165,3 +167,8 @@ module.exports = (options, env = {}) => new Plugin({
   task,
   env,
 });
+
+/**
+ * Export webpack
+ */
+module.exports.webpack = webpack;


### PR DESCRIPTION
Although we have a dependency graph for templates, the rebuilding isn't ideal:
* Let's assume we have a module which is included in many other modules and pages
* We are currently working on this module and viewing its preview page in the browser
* We are editing its template and want to see the result
* However, depending on how the files are streamed through the html build task, we might have to wait for all dependent modules and pages to be rebuilt until our preview page is taken care of

This PR introduces the following changes:
* We keep track of the currently viewed page in the browser
* We prioritize the rebuild of this page by putting it in front of the stream
* We immediately reload the browser when it has been rebuilt
* The remaining modules and pages are rebuilt in the background