### PR TITLE
gulp-sass: Don't report size of sourcemap files

### DIFF
--- a/packages/estatico-sass/index.js
+++ b/packages/estatico-sass/index.js
@@ -73,6 +73,7 @@ const task = (config, env = {}, watcher) => {
   const postcss = require('gulp-postcss');
   const sourcemaps = require('gulp-sourcemaps');
   const through = require('through2');
+  const ignore = require('gulp-ignore');
   const size = require('gulp-size');
 
   const autoprefixer = config.plugins.postcss.find(plugin => plugin.postcssPlugin === 'autoprefixer');
@@ -138,14 +139,17 @@ const task = (config, env = {}, watcher) => {
       sourceRoot: config.srcBase,
     }))
 
+    // Save
+    .pipe(gulp.dest(config.dest))
+
+    // Remove sourcemaps before logging size
+    .pipe(ignore.exclude(file => path.extname(file.path) === '.map'))
+
     // Log size
     .pipe(size({
       showFiles: true,
       title: 'estatico-sass',
-    }))
-
-    // Save
-    .pipe(gulp.dest(config.dest));
+    }));
 };
 
 /**

--- a/packages/estatico-sass/package.json
+++ b/packages/estatico-sass/package.json
@@ -16,6 +16,7 @@
     "autoprefixer": "^7.2.5",
     "chalk": "^2.3.0",
     "gulp": "github:gulpjs/gulp#4.0",
+    "gulp-ignore": "^2.0.2",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^7.0.1",
     "gulp-sass": "^3.1.0",


### PR DESCRIPTION
There is no use in logging the file size of sourcemap files, especially since they are counted towards the total. Instead, we should remove them from the stream before reporting the size.