### PR TITLE
[Fix] estatico-boilerplate: Dependency graph

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -55,13 +55,13 @@ gulp.task('html', () => {
             },
           },
           js: {
-            match: /require\('(.*?\.data\.js)'\)/g,
+            match: /(?:require\('(.*?\.data\.js)'\)|getFileContent\('(.*?)'\))/g,
             resolve: (match, filePath) => {
-              if (!match[1]) {
+              if (!(match[1] || match[2])) {
                 return null;
               }
 
-              return path.resolve(path.dirname(filePath), match[1]);
+              return path.resolve(path.dirname(filePath), match[1] || match[2]);
             },
           },
         },


### PR DESCRIPTION
Add handlebars file includes to data file's dependency graph. Otherwise, editing a module's template will not invalidate the cache for its data file.