### PR TITLE
[Update] estatico-webpack: Updated handlebars-loader to official package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8358,6 +8358,15 @@
 				}
 			}
 		},
+		"gulp-ignore": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+			"integrity": "sha1-XC6ioKRALgq0orzRLv2SlTRNePI=",
+			"requires": {
+				"gulp-match": "1.0.3",
+				"through2": "2.0.3"
+			}
+		},
 		"gulp-imagemin": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-4.1.0.tgz",
@@ -8374,6 +8383,14 @@
 				"plur": "2.1.2",
 				"pretty-bytes": "4.0.2",
 				"through2-concurrent": "1.1.1"
+			}
+		},
+		"gulp-match": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+			"integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+			"requires": {
+				"minimatch": "3.0.4"
 			}
 		},
 		"gulp-plumber": {
@@ -8922,7 +8939,9 @@
 			"integrity": "sha1-JrO+uTG0uHffv35v6vQFjuYiiwI="
 		},
 		"handlebars-loader": {
-			"version": "github:unic/handlebars-loader#60c3a9a9e163be747b7551b524a87c091f4ede2c",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.0.tgz",
+			"integrity": "sha512-tfS3n+PrDB2gnDnrx0/DGvdb4wF4JqV7CEiVof3RymOIWYrcmD+ZiaXTlZ/f7fZ7+aQPEv6JRG0HS7nTlyvGlQ==",
 			"requires": {
 				"async": "0.2.10",
 				"fastparse": "1.1.1",

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -20,7 +20,7 @@
     "chalk": "^2.3.0",
     "css-loader": "^0.28.9",
     "expose-loader": "^0.7.4",
-    "handlebars-loader": "github:unic/handlebars-loader",
+    "handlebars-loader": "^1.7.0",
     "lodash.merge": "^4.6.0",
     "lodash.once": "^4.1.1",
     "style-loader": "^0.20.1",


### PR DESCRIPTION
Our fix for webpack 4 was merged upstream, so no need to use our fork anymore