### PR TITLE
[utils] Removed dependency on estatico-watch

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -66,8 +66,8 @@ gulp.task('html', () => {
             },
           },
         },
-        watcher: estaticoWatch,
       },
+      watcher: estaticoWatch,
     },
     plugins: {
       handlebars: {
@@ -213,8 +213,8 @@ gulp.task('css', () => {
             },
           },
         },
-        watcher: estaticoWatch,
       },
+      watcher: estaticoWatch,
     },
     plugins: {
       sass: {

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -14,6 +14,7 @@ const env = require('minimist')(process.argv.slice(2));
  */
 gulp.task('html', () => {
   const task = require('@unic/estatico-handlebars');
+  const estaticoWatch = require('@unic/estatico-watch');
   const estaticoQunit = require('@unic/estatico-qunit');
   const { readFileSyncCached } = require('@unic/estatico-utils');
 
@@ -65,6 +66,7 @@ gulp.task('html', () => {
             },
           },
         },
+        watcher: estaticoWatch,
       },
     },
     plugins: {
@@ -158,6 +160,7 @@ gulp.task('html:validate', () => {
  */
 gulp.task('css', () => {
   const task = require('@unic/estatico-sass');
+  const estaticoWatch = require('@unic/estatico-watch');
   const nodeSassJsonImporter = require('node-sass-json-importer');
   const autoprefixer = require('autoprefixer');
 
@@ -210,6 +213,7 @@ gulp.task('css', () => {
             },
           },
         },
+        watcher: estaticoWatch,
       },
     },
     plugins: {

--- a/packages/estatico-boilerplate/package.json
+++ b/packages/estatico-boilerplate/package.json
@@ -36,7 +36,7 @@
     "change-case": "^3.0.2",
     "del": "^3.0.0",
     "glob": "^7.1.2",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "inquirer": "^5.2.0",
     "lodash.merge": "^4.6.1",
     "minimist": "^1.2.0",

--- a/packages/estatico-copy/index.js
+++ b/packages/estatico-copy/index.js
@@ -44,7 +44,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config /* , env = {} */) => {

--- a/packages/estatico-copy/package.json
+++ b/packages/estatico-copy/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-changed-in-place": "^2.3.0",
     "gulp-plumber": "^1.2.0",
     "joi": "^13.2.0",

--- a/packages/estatico-eslint/package.json
+++ b/packages/estatico-eslint/package.json
@@ -15,7 +15,7 @@
     "chalk": "^2.4.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.11.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-changed-in-place": "^2.3.0",
     "gulp-eslint": "^4.0.2",
     "gulp-plumber": "^1.2.0",

--- a/packages/estatico-font-datauri/index.js
+++ b/packages/estatico-font-datauri/index.js
@@ -39,7 +39,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-font-datauri/package.json
+++ b/packages/estatico-font-datauri/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-plumber": "^1.2.0",
     "gulp-simplefont64": "github:unic/gulp-simplefont64",

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -78,8 +78,8 @@ gulp.task('html', () => {
             },
           },
         },
-        watcher: estaticoWatch,
       },
+      watcher: estaticoWatch,
     },
     plugins: {
       clone: null,

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -26,6 +26,7 @@ const env = require('minimist')(process.argv.slice(2));
  */
 gulp.task('html', () => {
   const task = require('@unic/estatico-handlebars');
+  const estaticoWatch = require('@unic/estatico-watch');
   const estaticoQunit = require('@unic/estatico-qunit');
   const { readFileSyncCached } = require('@unic/estatico-utils');
 
@@ -77,6 +78,7 @@ gulp.task('html', () => {
             },
           },
         },
+        watcher: estaticoWatch,
       },
     },
     plugins: {

--- a/packages/estatico-handlebars/index.js
+++ b/packages/estatico-handlebars/index.js
@@ -13,6 +13,11 @@ const schema = Joi.object().keys({
   watch: Joi.object().keys({
     src: [Joi.string().required(), Joi.array().required()],
     name: Joi.string().required(),
+    dependencyGraph: Joi.object().keys({
+      srcBase: Joi.string().required(),
+      resolver: Joi.object().required(),
+      watcher: Joi.func().required(),
+    }),
   }).allow(null),
   plugins: {
     handlebars: Joi.object().keys({

--- a/packages/estatico-handlebars/index.js
+++ b/packages/estatico-handlebars/index.js
@@ -16,9 +16,9 @@ const schema = Joi.object().keys({
     dependencyGraph: Joi.object().keys({
       srcBase: Joi.string().required(),
       resolver: Joi.object().required(),
-      watcher: Joi.func().required(),
     }),
-  }).allow(null),
+    watcher: Joi.func(),
+  }).with('dependencyGraph', 'watcher').allow(null),
   plugins: {
     handlebars: Joi.object().keys({
       handlebars: Joi.object().allow(null),
@@ -100,7 +100,7 @@ const defaults = env => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}, watcher) => {

--- a/packages/estatico-handlebars/package.json
+++ b/packages/estatico-handlebars/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-hb": "^7.0.1",
     "gulp-plumber": "^1.2.0",
     "gulp-prettify": "^0.5.0",
@@ -21,7 +21,7 @@
     "handlebars-layouts": "^3.1.4",
     "handlebars-wax": "^6.1.0",
     "joi": "^13.2.0",
-    "lodash.merge": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
@@ -34,7 +34,6 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "del": "^3.0.0",
-    "lodash.merge": "^4.6.1",
     "sinon": "^5.0.7"
   }
 }

--- a/packages/estatico-imageversions/index.js
+++ b/packages/estatico-imageversions/index.js
@@ -53,7 +53,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-imageversions/package.json
+++ b/packages/estatico-imageversions/package.json
@@ -14,7 +14,7 @@
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
     "gm": "^1.23.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-imagemin": "^4.1.0",
     "gulp-plumber": "^1.2.0",
     "gulp-size": "^3.0.0",

--- a/packages/estatico-json-mocks/index.js
+++ b/packages/estatico-json-mocks/index.js
@@ -40,7 +40,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config /* , env = {} */) => {

--- a/packages/estatico-json-mocks/package.json
+++ b/packages/estatico-json-mocks/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-plumber": "^1.2.0",
     "joi": "^13.2.0",
     "through2": "^2.0.3"

--- a/packages/estatico-puppeteer/index.js
+++ b/packages/estatico-puppeteer/index.js
@@ -44,7 +44,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-sass/README.md
+++ b/packages/estatico-sass/README.md
@@ -26,6 +26,7 @@ const env = require('minimist')(process.argv.slice(2));
  */
 gulp.task('css', () => {
   const task = require('@unic/estatico-sass');
+  const estaticoWatch = require('@unic/estatico-watch');
   const nodeSassJsonImporter = require('node-sass-json-importer');
   const autoprefixer = require('autoprefixer');
 
@@ -78,6 +79,7 @@ gulp.task('css', () => {
             },
           },
         },
+        watcher: estaticoWatch,
       },
     },
     plugins: {

--- a/packages/estatico-sass/README.md
+++ b/packages/estatico-sass/README.md
@@ -79,8 +79,8 @@ gulp.task('css', () => {
             },
           },
         },
-        watcher: estaticoWatch,
       },
+      watcher: estaticoWatch,
     },
     plugins: {
       sass: {

--- a/packages/estatico-sass/index.js
+++ b/packages/estatico-sass/index.js
@@ -21,9 +21,9 @@ const schema = Joi.object().keys({
     dependencyGraph: Joi.object().keys({
       srcBase: Joi.string().required(),
       resolver: Joi.object().required(),
-      watcher: Joi.func().required(),
     }),
-  }).allow(null),
+    watcher: Joi.func(),
+  }).with('dependencyGraph', 'watcher').allow(null),
   logger: Joi.object().keys({
     info: Joi.func(),
     error: Joi.func(),
@@ -66,7 +66,7 @@ const defaults = (env = {}) => {
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Optional environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}, watcher) => {

--- a/packages/estatico-sass/index.js
+++ b/packages/estatico-sass/index.js
@@ -18,6 +18,11 @@ const schema = Joi.object().keys({
   watch: Joi.object().keys({
     src: [Joi.string().required(), Joi.array().required()],
     name: Joi.string().required(),
+    dependencyGraph: Joi.object().keys({
+      srcBase: Joi.string().required(),
+      resolver: Joi.object().required(),
+      watcher: Joi.func().required(),
+    }),
   }).allow(null),
   logger: Joi.object().keys({
     info: Joi.func(),

--- a/packages/estatico-sass/package.json
+++ b/packages/estatico-sass/package.json
@@ -15,7 +15,7 @@
     "@unic/estatico-watch": "0.0.8",
     "autoprefixer": "^8.4.1",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-ignore": "^2.0.2",
     "gulp-plumber": "^1.2.0",
     "gulp-postcss": "^7.0.1",
@@ -23,7 +23,7 @@
     "gulp-size": "^3.0.0",
     "gulp-sourcemaps": "^2.6.4",
     "joi": "^13.2.0",
-    "lodash.merge": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "postcss-clean": "^1.1.0",
     "postcss-filter-stream": "^0.0.6",
     "through2": "^2.0.3"
@@ -37,7 +37,6 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "del": "^3.0.0",
-    "lodash.merge": "^4.6.1",
     "sinon": "^5.0.7"
   }
 }

--- a/packages/estatico-scaffold/package.json
+++ b/packages/estatico-scaffold/package.json
@@ -14,7 +14,7 @@
     "@unic/estatico-utils": "0.0.8",
     "del": "^3.0.0",
     "glob": "^7.1.2",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "joi": "^13.2.0",
     "node-plop": "^0.13.0",
     "through2": "^2.0.3"

--- a/packages/estatico-stylelint/index.js
+++ b/packages/estatico-stylelint/index.js
@@ -49,7 +49,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-stylelint/package.json
+++ b/packages/estatico-stylelint/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-changed-in-place": "^2.3.0",
     "gulp-plumber": "^1.2.0",
     "gulp-stylelint": "^7.0.0",

--- a/packages/estatico-svgsprite/index.js
+++ b/packages/estatico-svgsprite/index.js
@@ -63,7 +63,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-svgsprite/package.json
+++ b/packages/estatico-svgsprite/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-imagemin": "^4.1.0",
     "gulp-plumber": "^1.2.0",
     "gulp-size": "^3.0.0",
     "gulp-svgstore": "^6.1.1",
     "joi": "^13.2.0",
-    "lodash.merge": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "merge-stream": "^1.0.1",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "ava": "^0.25.0",
-    "del": "^3.0.0",
-    "lodash.merge": "^4.6.1"
+    "del": "^3.0.0"
   }
 }

--- a/packages/estatico-utils/lib/plugin.js
+++ b/packages/estatico-utils/lib/plugin.js
@@ -34,8 +34,9 @@ function plugin({
       task: task.bind(null, config, env),
     }, config.watch);
 
-    if (config.watch.dependencyGraph && config.watch.dependencyGraph.watcher) {
-      config.watch.dependencyGraph.watcher(watchConfig)();
+    if (config.watch.watcher) {
+      // Use custom watcher like `@unic/estatico-watch`
+      config.watch.watcher(watchConfig)();
     } else {
       // Create named callback function for gulp-cli to be able to log it
       const cb = {
@@ -44,6 +45,7 @@ function plugin({
         },
       };
 
+      // Use default gulp watch
       gulp.watch(watchConfig.src, cb[config.watch.name]);
     }
   }

--- a/packages/estatico-utils/lib/plugin.js
+++ b/packages/estatico-utils/lib/plugin.js
@@ -7,8 +7,8 @@ function plugin({
   env = {},
 }) {
   const merge = require('lodash.merge');
-  const watcher = require('@unic/estatico-watch');
   const Joi = require('joi');
+  const gulp = require('gulp');
 
   let config = {};
 
@@ -34,7 +34,18 @@ function plugin({
       task: task.bind(null, config, env),
     }, config.watch);
 
-    watcher(watchConfig)();
+    if (config.watch.dependencyGraph && config.watch.dependencyGraph.watcher) {
+      config.watch.dependencyGraph.watcher(watchConfig)();
+    } else {
+      // Create named callback function for gulp-cli to be able to log it
+      const cb = {
+        [config.watch.name]() {
+          return watchConfig.task();
+        },
+      };
+
+      gulp.watch(watchConfig.src, cb[config.watch.name]);
+    }
   }
 
   // Return configured task function

--- a/packages/estatico-utils/package.json
+++ b/packages/estatico-utils/package.json
@@ -10,11 +10,11 @@
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-utils",
   "license": "Apache-2.0",
   "dependencies": {
-    "@unic/estatico-watch": "0.0.8",
     "chalk": "^2.4.1",
     "fancy-log": "^1.3.2",
     "glob": "^7.1.2",
     "gm": "^1.23.1",
+    "gulp": "^4.0.0",
     "gulplog": "^1.0.0",
     "joi": "^13.2.0",
     "lodash.merge": "^4.6.1",

--- a/packages/estatico-w3c-validator/index.js
+++ b/packages/estatico-w3c-validator/index.js
@@ -41,7 +41,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}) => {

--- a/packages/estatico-w3c-validator/package.json
+++ b/packages/estatico-w3c-validator/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@unic/estatico-utils": "0.0.8",
     "chalk": "^2.4.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-changed-in-place": "^2.3.0",
     "gulp-plumber": "^1.2.0",
     "gulp-w3cjs": "^1.3.0",

--- a/packages/estatico-watch/index.js
+++ b/packages/estatico-watch/index.js
@@ -41,7 +41,7 @@ const defaults = (/* env */) => ({
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config /* , env = {} */) => {

--- a/packages/estatico-webpack/index.js
+++ b/packages/estatico-webpack/index.js
@@ -114,7 +114,7 @@ const defaults = (env) => {
  * Task function
  * @param {object} config - Complete task config
  * @param {object} env - Environment config, e.g. { dev: true }
- * @param {object} [watcher] - Watch file events
+ * @param {object} [watcher] - Watch file events (requires `@unic/estatico-watch`) (requires `@unic/estatico-watch`)
  * @return {object} gulp stream
  */
 const task = (config, env = {}, cb) => {

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -22,7 +22,7 @@
     "expose-loader": "^0.7.5",
     "handlebars-loader": "^1.7.0",
     "joi": "^13.2.0",
-    "lodash.merge": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "lodash.once": "^4.1.1",
     "style-loader": "^0.21.0",
     "uglifyjs-webpack-plugin": "^1.2.5",
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "ava": "^0.25.0",
-    "del": "^3.0.0",
-    "lodash.merge": "^4.6.1"
+    "del": "^3.0.0"
   }
 }


### PR DESCRIPTION
See #46 

* [utils] Removed dependency on estatico-watch. Pass watcher as part of `watch` instead, fall back to `gulp.watch` otherwise. Required if `watch.dependencyGraph` is specified.
* [sass, handlebars, boilerplate] Updated config
* Chore: Replace `"gulp": "github:gulpjs/gulp#4.0"` with `"gulp": "^4.0.0"`