### PR TITLE
Feature/fix missing export skiplinks

### DIFF
--- a/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
+++ b/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
@@ -8,7 +8,6 @@ import $ from 'jquery';
 /** Demo modules * */
 import SkipLinks from '../../../demo/modules/skiplinks/skiplinks.js';
 import SlideShow from '../../../demo/modules/slideshow/slideshow';
-import MainNavigation from '../../../modules/main-navigation/main-navigation';
 /* autoinsertmodulereference */ // eslint-disable-line
 
 class EstaticoApp {

--- a/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
+++ b/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
@@ -6,22 +6,25 @@
 import $ from 'jquery';
 
 /** Demo modules * */
-import SkipLinks from '../../../demo/modules/skiplinks/skiplinks';
+import SkipLinks from '../../../demo/modules/skiplinks/skiplinks.js';
 import SlideShow from '../../../demo/modules/slideshow/slideshow';
+import MainNavigation from '../../../modules/main-navigation/main-navigation';
 /* autoinsertmodulereference */ // eslint-disable-line
 
 class EstaticoApp {
   constructor() {
-    // Module instances
+    // Module instances`
     window.estatico.modules = {};
 
     this.initEvents = [];
 
+    SkipLinks.init();
+
     // Module registry - mapping module name (used in data-init) to module Class
     this.modules = {};
     this.modules.slideshow = SlideShow;
-    this.modules.skiplinks = SkipLinks;
-		/* autoinsertmodule */ // eslint-disable-line
+    this.modules.mainNavigation = MainNavigation;
+    /* autoinsertmodule */ // eslint-disable-line
 
     // expose initModule function
     estatico.helpers.initModule = this.initModule;
@@ -90,8 +93,8 @@ class EstaticoApp {
 
       modules.forEach((moduleName) => {
         if (this.isRegistered(moduleName)
-            && !this.isInitialised($element, moduleName)
-            && this.isInitEvent(event.type, moduleName)) {
+          && !this.isInitialised($element, moduleName)
+          && this.isInitEvent(event.type, moduleName)) {
           this.initModule(moduleName, $element);
         }
       });

--- a/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
+++ b/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
@@ -12,7 +12,7 @@ import SlideShow from '../../../demo/modules/slideshow/slideshow';
 
 class EstaticoApp {
   constructor() {
-    // Module instances`
+    // Module instances
     window.estatico.modules = {};
 
     this.initEvents = [];

--- a/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
+++ b/packages/estatico-boilerplate/src/assets/js/helpers/estaticoapp.js
@@ -6,7 +6,7 @@
 import $ from 'jquery';
 
 /** Demo modules * */
-import SkipLinks from '../../../demo/modules/skiplinks/skiplinks.js';
+import SkipLinks from '../../../demo/modules/skiplinks/skiplinks';
 import SlideShow from '../../../demo/modules/slideshow/slideshow';
 /* autoinsertmodulereference */ // eslint-disable-line
 
@@ -22,7 +22,6 @@ class EstaticoApp {
     // Module registry - mapping module name (used in data-init) to module Class
     this.modules = {};
     this.modules.slideshow = SlideShow;
-    this.modules.mainNavigation = MainNavigation;
     /* autoinsertmodule */ // eslint-disable-line
 
     // expose initModule function

--- a/packages/estatico-boilerplate/src/demo/modules/skiplinks/skiplinks.js
+++ b/packages/estatico-boilerplate/src/demo/modules/skiplinks/skiplinks.js
@@ -1,3 +1,3 @@
 import SkipLinkFocus from 'skip-link-focus';
 
-SkipLinkFocus.init();
+export default SkipLinkFocus;


### PR DESCRIPTION
This warning: 

```
WARNING in ./src/assets/js/helpers/estaticoapp.js 50:29-38
    "export 'default' (imported as 'SkipLinks') was not found in '../../../demo/modules/skiplinks/skiplinks.js'
     @ ./src/assets/js/main.js
```

is triggered the first time we build because Skiplinks doesn't export anything.

I basically export the import from Skiplinks (because this time this plugin makes nothing else) and removed Skiplinks from the module registry in `estaticoapp.js` to initialize it in the constructor.