### PR TITLE
[Update] estatico-font-datauri: Added rename option

### DIFF
--- a/packages/estatico-font-datauri/README.md
+++ b/packages/estatico-font-datauri/README.md
@@ -92,6 +92,13 @@ Default: `null`
 
 Passed to [`gulp-concat`](https://www.npmjs.com/package/gulp-concat).
 
+##### plugins.rename
+
+Type: `Function`<br>
+Default: `null`
+
+Result will be assigned to `file.path` before passing the file to [`gulp-simplefont64`](https://github.com/unic/gulp-simplefont64). This allows you to optionally generate file names which can be handled by the plugin (e.g. `FontFamily-FontStyle`).
+
 #### logger
 
 Type: `{ info: Function, debug: Function, error: Function }`<br>


### PR DESCRIPTION
Situation: We might have to use external font files where we don't control the names.

Example config renaming an input file `frutiger45light` to `Frutiger-Light`, allowing `gulp-simplefont64` to generate `@font-family { font-family: Frutiger; font-weight: 300; }`:
```
rename: filePath => filePath.replace(/frutiger45light/, 'Frutiger-Light'),
```