### PR TITLE
Puppeteer / QUnit

### DIFF
--- a/packages/estatico-puppeteer/index.js
+++ b/packages/estatico-puppeteer/index.js
@@ -99,8 +99,7 @@ const task = (config, env = {}) => {
     const tests = files.map(async (file) => {
       // Get available page
       const page = await pagePool.acquire();
-
-      config.logger.info(`Testing ${chalk.yellow(path.relative(config.srcBase, file))}`);
+      const filePathLog = chalk.yellow(path.relative(config.srcBase, file));
 
       // Open file
       await page.goto(`file://${file}`);
@@ -111,17 +110,21 @@ const task = (config, env = {}) => {
           if (config.viewports) {
             // eslint-disable-next-line no-restricted-syntax
             for (const viewport of Object.keys(config.viewports)) {
-              config.logger.info(`Testing viewport ${chalk.yellow(viewport)}`);
+              config.logger.info(`Testing ${filePathLog} in viewport ${chalk.yellow(viewport)}`);
 
               await page.setViewport(config.viewports[viewport]);
               await config.plugins.interact(page, config.logger);
             }
           } else {
+            config.logger.info(`Testing ${filePathLog}`);
+
             await config.plugins.interact(page, config.logger);
           }
         } catch (err) {
           error = err;
         }
+      } else {
+        config.logger.info(`Opening ${filePathLog}`);
       }
 
       // Handle errors: Exit on error (see note in 'pageerror' handler)

--- a/packages/estatico-qunit/README.md
+++ b/packages/estatico-qunit/README.md
@@ -1,4 +1,4 @@
-# @unic/estatico-qunit [WIP]
+# @unic/estatico-qunit [Deprecated]
 
 Helpers for QUnit tests
 
@@ -14,16 +14,16 @@ Add the following config to the `estatico-puppeteer`'s options:
 ```js
 {
   plugins: {
-    interact: {
-      interact: async (page) => {
-        // Run tests
-        const results = await require('@unic/estatico-qunit').puppeteer.run(page);
+    interact: async (page) => {
+      // Run tests
+      const results = await require('@unic/estatico-qunit').puppeteer.run(page);
 
-        // Report results
-        if (results) {
-          require('@unic/estatico-qunit').puppeteer.log(results);
-        }
-      },
+      // Report results
+      if (results) {
+        require('@unic/estatico-qunit').puppeteer.log(results, {
+          info: console.log,
+        });
+      }
     },
   },
 };
@@ -31,17 +31,17 @@ Add the following config to the `estatico-puppeteer`'s options:
 
 Include test script in `src/preview/assets/js/main.js`, e.g.:
 ```js
-import 'estatico-qunit/lib/browser';
+import '@unic/estatico-qunit/lib/browser';
 ```
 
-Add the following config to the `estatico-handlebars`'s options:
+Add the following config to the `estatico-handlebars`'s options to provide the `qunit` helper below:
 ```js
 {
   plugins: {
     handlebars: {
       helpers: {
         register: () => {
-          handlebars.registerHelper('qunit', estaticoQunit.handlebarsHelper(handlebars));
+          handlebars.registerHelper('qunit', require('@unic/estatico-qunit').handlebarsHelper(handlebars));
         },
       }
     },


### PR DESCRIPTION
Implementing QUnit with Puppeteer on an existing project (where we already had QUnit tests and didn't want to rewrite them to use Jest for now), I discovered the following issues:
- The logging didn't make too much sense when using a pool of connections since there was a wild mix of `Testing X.html` and `Testing viewport Y` without any connection between them. That's why I have combined these logs now so it is always clear which file we are talking about.
- The instructions for the QUnit implementation were incorrect