### PR TITLE
[Fix] estatico-webpack: Fixed error handler

### DIFF
--- a/packages/estatico-webpack/index.js
+++ b/packages/estatico-webpack/index.js
@@ -57,7 +57,7 @@ const task = (config, env = {}, cb) => {
       }
 
       if (err) {
-        config.errorHandler(err);
+        config.logger.error(err);
       }
 
       config.logger.info(format(stats));


### PR DESCRIPTION
There was an outdated reference to the error handler