### PR TITLE
fix(estatico-watch): add check for accidental directory match, improve boilerplate config

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -247,7 +247,10 @@ gulp.task('css', () => {
                 return [...new Set(candidatePaths)];
               }).reduce((arr, curr) => arr.concat(curr), []); // Flatten
 
-              return candidates.find(fs.existsSync) || null;
+              return candidates.find((candiatePath) => { // eslint-disable-line arrow-body-style
+                // Ignore inexistent files
+                return fs.existsSync(candiatePath) && fs.statSync(candiatePath).isFile();
+              }) || null;
             },
           },
         },

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -247,9 +247,9 @@ gulp.task('css', () => {
                 return [...new Set(candidatePaths)];
               }).reduce((arr, curr) => arr.concat(curr), []); // Flatten
 
-              return candidates.find((candiatePath) => { // eslint-disable-line arrow-body-style
+              return candidates.find((candidatePath) => { // eslint-disable-line arrow-body-style
                 // Ignore inexistent files
-                return fs.existsSync(candiatePath) && fs.statSync(candiatePath).isFile();
+                return fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile();
               }) || null;
             },
           },

--- a/packages/estatico-watch/lib/dependencygraph.js
+++ b/packages/estatico-watch/lib/dependencygraph.js
@@ -127,7 +127,13 @@ class DependencyGraph {
       return null;
     }
 
-    const timestamp = fs.statSync(filePath).mtime.getTime();
+    const stats = fs.statSync(filePath);
+
+    if (!stats.isFile()) {
+      return null;
+    }
+
+    const timestamp = stats.mtime.getTime();
 
     if (this.cache[filePath] && this.cache[filePath].timestamp === timestamp) {
       return this.cache[filePath].content;


### PR DESCRIPTION
- When the dependency graph resolver accidentally return a directory, we should ignore it instead of failing with EISDIR.
- By default, the CSS dependency graph should not return directories.