### PR TITLE
Jest: Add puppeteer launch args for CI

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -426,7 +426,7 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
   const { spawn } = require('child_process');
   let failed = false;
 
-  const tests = spawn('npm', ['run', 'jest'], {
+  const tests = spawn('npm', ['run', 'jest'].concat(env.ci ? ['--', '--ci'] : []), {
     // Add proper output coloring unless in CI env (where this would have weird side-effects)
     stdio: env.ci ? 'pipe' : ['inherit', 'inherit', 'pipe'],
   });

--- a/packages/estatico-boilerplate/jest.config.js
+++ b/packages/estatico-boilerplate/jest.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const env = require('minimist')(process.argv.slice(2));
 
 const dir = path.dirname(require.resolve('@unic/estatico-jest'));
 
@@ -10,12 +11,13 @@ module.exports = {
   projects: [{
     // This seems to be the only way for now to pass options to setup.js
     // https://github.com/facebook/jest/issues/5957#issuecomment-422027349
-    projects: [{
-      // We temporarily run a static webserver where Puppeteer can access our HTML
-      puppeteerServer: {
-        port: 3000,
-        dir: './dist',
+    puppeteerServer: {
+      port: 3000,
+      dir: './dist',
+      puppeteer: {
+        // Our current Teamcity agents expect Puppeteer to run in no-sandbox mode
+        args: env.ci ? ['--no-sandbox'] : [],
       },
-    }],
+    },
   }],
 };

--- a/packages/estatico-jest/README.md
+++ b/packages/estatico-jest/README.md
@@ -28,6 +28,10 @@ $ npm install --save-dev jest @unic/estatico-jest
       puppeteerServer: {
         port: 3000,
         dir: './dist',
+        puppeteer: {
+          // Our current Teamcity agents expect Puppeteer to run in no-sandbox mode
+          args: env.ci ? ['--no-sandbox'] : [],
+        },
       },
     }],
   };

--- a/packages/estatico-jest/setup.js
+++ b/packages/estatico-jest/setup.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const handler = require('serve-handler');
 const http = require('http');
 
-async function launchPuppeteer() {
-  const browser = await puppeteer.launch();
+async function launchPuppeteer(config) {
+  const browser = await puppeteer.launch(config);
   const browserEndpoint = browser.wsEndpoint();
 
   // Store browser instance so we can tear it down in the end
@@ -40,7 +40,7 @@ module.exports = async (globalConfig) => {
   }, customServerConfig);
 
   // Start puppeteer and expose connection ednpoint
-  const browserEndpoint = await launchPuppeteer();
+  const browserEndpoint = await launchPuppeteer(serverConfig.puppeteer);
 
   // Serve static build on port 3000
   const staticPort = await launchStaticServer(serverConfig);


### PR DESCRIPTION
We currently need to pass `args: ['--no-sandbox']` to Puppeteer when running on Teamcity.