### PR TITLE
fix(estatico-jest): add fallback for missing process in teardown

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -440,7 +440,7 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
     }
 
     // Travis will kill the whole process for whatever reason
-    if (stripAnsi(`${data}`) === 'Killed') {
+    if (stripAnsi(`${data}`).match(/Killed/m)) {
       killed = true;
     }
 

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -424,6 +424,8 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
   }
 
   const { spawn } = require('child_process');
+  const stripAnsi = require('strip-ansi');
+
   let failed = false;
 
   const tests = spawn('npm', ['run', 'jest'].concat(env.ci ? ['--', '--ci'] : []), {
@@ -432,7 +434,7 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
   });
 
   tests.stderr.on('data', (data) => {
-    if (`${data}`.match(/Test Suites: (.*?) failed/m)) {
+    if (stripAnsi(`${data}`).match(/(Test Suites: (.*?) failed|npm ERR!)/m)) {
       failed = true;
     }
 

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -427,6 +427,7 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
   const stripAnsi = require('strip-ansi');
 
   let failed = false;
+  let killed = false;
 
   const tests = spawn('npm', ['run', 'jest'].concat(env.ci ? ['--', '--ci'] : []), {
     // Add proper output coloring unless in CI env (where this would have weird side-effects)
@@ -438,11 +439,16 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
       failed = true;
     }
 
+    // Travis will kill the whole process for whatever reason
+    if (stripAnsi(`${data}`) === 'Killed') {
+      killed = true;
+    }
+
     process.stderr.write(data);
   });
 
   tests.on('close', () => {
-    if (failed && !env.dev) {
+    if (failed && !env.dev && !killed) {
       process.exit(1);
     }
 

--- a/packages/estatico-boilerplate/package.json
+++ b/packages/estatico-boilerplate/package.json
@@ -42,7 +42,8 @@
     "inquirer": "^5.2.0",
     "lodash.merge": "^4.6.1",
     "minimist": "^1.2.0",
-    "node-sass-json-importer": "^3.2.0"
+    "node-sass-json-importer": "^3.2.0",
+    "strip-ansi": "^5.0.0"
   },
   "dependencies": {
     "bows": "^1.7.0",

--- a/packages/estatico-jest/teardown.js
+++ b/packages/estatico-jest/teardown.js
@@ -14,5 +14,10 @@ module.exports = async () => {
 
   // Find and stop static server
   const [process] = await findProcess('port', global.__STATIC_PORT_GLOBAL__);
-  await asyncTerminate(process.pid);
+
+  if (process) {
+    await asyncTerminate(process.pid);
+  } else {
+    console.log(`Jest teardown: No process found on port ${global.__STATIC_PORT_GLOBAL__}, static file server was apparently stopped already`);
+  }
 };


### PR DESCRIPTION
- Teamcity does not seem to find the process in teardown, throwing an error
- `js:test` isn't properly handling this kind of error