### PR TITLE
fix(estatico-jest): fix teardown not finding process

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -440,12 +440,12 @@ gulp.task('js:test', (done) => { // eslint-disable-line consistent-return
       failed = true;
     }
 
-    // Travis will kill the whole process for whatever reason
+    // Don't treat as failure: Travis seems to kill the whole process for whatever reason
     if (stripAnsi(`${data}`).match(/Killed/m)) {
       killed = true;
     }
 
-    // Teamcity has other issues
+    // Don't treat as failure: The web server might have stopped or the process could not be found
     if (stripAnsi(`${data}`).match(/No process found on port/m)) {
       teardownFailed = true;
     }
@@ -586,7 +586,7 @@ gulp.task('scaffold', () => {
         name: 'Module',
         src: './src/modules/.scaffold/*',
         dest: './src/modules/',
-        transformInput : (answers) => {
+        transformInput: (answers) => {
           const changeCase = require('change-case'),
             name = answers.newName || answers.name;
 

--- a/packages/estatico-jest/README.md
+++ b/packages/estatico-jest/README.md
@@ -79,12 +79,12 @@ $ npm install --save-dev jest @unic/estatico-jest
         failed = true;
       }
 
-      // Travis will kill the whole process for whatever reason
+      // Don't treat as failure: Travis seems to kill the whole process for whatever reason
       if (stripAnsi(`${data}`).match(/Killed/m)) {
         killed = true;
       }
 
-      // Teamcity has other issues
+      // Don't treat as failure: The web server might have stopped or the process could not be found
       if (stripAnsi(`${data}`).match(/No process found on port/m)) {
         teardownFailed = true;
       }

--- a/packages/estatico-jest/package.json
+++ b/packages/estatico-jest/package.json
@@ -10,8 +10,8 @@
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-jest",
   "license": "Apache-2.0",
   "dependencies": {
-    "find-process": "^1.1.3",
     "jest-environment-node": "^23.4.0",
+    "lsofi": "^1.0.0",
     "puppeteer": "^1.8.0",
     "serve-handler": "^5.0.2",
     "terminate": "^2.1.0"

--- a/packages/estatico-jest/teardown.js
+++ b/packages/estatico-jest/teardown.js
@@ -1,6 +1,6 @@
 const util = require('util');
 const fs = require('fs');
-const findProcess = require('find-process');
+const lsofi = require('lsofi');
 const terminate = require('terminate');
 
 const asyncTerminate = util.promisify(terminate);
@@ -13,14 +13,14 @@ module.exports = async () => {
   fs.unlinkSync('./.tmp-test-config.json');
 
   // Find and stop static server
-  const [process] = await findProcess('port', global.__STATIC_PORT_GLOBAL__);
+  const port = await lsofi(global.__STATIC_PORT_GLOBAL__);
 
-  if (process) {
-    await asyncTerminate(process.pid);
+  if (port) {
+    await asyncTerminate(port);
   } else {
     throw new Error(`
-  Jest teardown: No process found on port ${global.__STATIC_PORT_GLOBAL__}, static file server was apparently stopped already.
-  This is not an issue with the tests themselves and might be ignored.
+  Jest teardown: No process found on port ${global.__STATIC_PORT_GLOBAL__}, static file server was apparently stopped already or cannot be found.
+  This is not an issue with the tests themselves and might be ignored, however, in the latter case you will end up with a running process on the port specified in the jest config.
   Throwing this error will make sure Jest properly stops anyway.
 `);
   }


### PR DESCRIPTION
The previous `find-process` helper did not find the process on our Teamcity agents, leaving us with a running process on port `3000`. `lsofi` seems to work more cross-platformy.