### PR TITLE
fix(estatico-jest): lock down event-stream

### DIFF
--- a/packages/estatico-jest/package.json
+++ b/packages/estatico-jest/package.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/unic/estatico-nou/tree/master/packages/estatico-jest",
   "license": "Apache-2.0",
   "dependencies": {
+    "event-stream": "3.3.4",
     "jest-environment-node": "^23.4.0",
     "lsofi": "^1.0.0",
     "puppeteer": "^1.8.0",


### PR DESCRIPTION
In order to prevent users from using a cached version of `event-stream` relying on the malicious `flatmap-stream` package, we should lock `event-stream` at 3.3.4: https://github.com/dominictarr/event-stream/issues/116