### PR TITLE
feat(estatico-sass): add custom importer for CSS files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
   "gitVersionPrefix": "v",
   "command": {
     "bootstrap": {
-      "hoist": true,
+      "hoist": false,
       "npmClientArgs": ["--no-package-lock"],
       "ci": false
     },

--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -200,7 +200,6 @@ gulp.task('data:lint', () => {
 gulp.task('css', () => {
   const task = require('@unic/estatico-sass');
   const estaticoWatch = require('@unic/estatico-watch');
-  const nodeSassJsonImporter = require('node-sass-json-importer');
 
   const instance = task({
     src: [
@@ -262,10 +261,6 @@ gulp.task('css', () => {
         includePaths: [
           './src/',
           './src/assets/css/',
-        ],
-        importer: [
-          // Add importer being able to deal with json files like colors, e.g.
-          nodeSassJsonImporter,
         ],
       },
       // Use task default (autoprefixer with .browserslistrc config)

--- a/packages/estatico-boilerplate/package.json
+++ b/packages/estatico-boilerplate/package.json
@@ -42,7 +42,6 @@
     "inquirer": "^5.2.0",
     "lodash.merge": "^4.6.1",
     "minimist": "^1.2.0",
-    "node-sass-json-importer": "^3.2.0",
     "strip-ansi": "^5.0.0"
   },
   "dependencies": {

--- a/packages/estatico-boilerplate/src/assets/css/main.scss
+++ b/packages/estatico-boilerplate/src/assets/css/main.scss
@@ -6,7 +6,7 @@
 
 
 // Reset / normalize styles
-@import "../../../node_modules/normalize.css/normalize";
+@import "../../../node_modules/normalize.css/normalize.css";
 
 // Icons (as font or dataurl), PNG sprites
 // @import "../.tmp/iconfont";

--- a/packages/estatico-boilerplate/src/preview/assets/css/main.scss
+++ b/packages/estatico-boilerplate/src/preview/assets/css/main.scss
@@ -3,7 +3,7 @@
 @import "globals/functions";
 @import "globals/mixins";
 @import "globals/mediaqueries";
-@import "../../../node_modules/highlight.js/styles/github";
+@import "../../../../node_modules/highlight.js/styles/github.css";
 
 
 

--- a/packages/estatico-sass/README.md
+++ b/packages/estatico-sass/README.md
@@ -27,7 +27,6 @@ const env = require('minimist')(process.argv.slice(2));
 gulp.task('css', () => {
   const task = require('@unic/estatico-sass');
   const estaticoWatch = require('@unic/estatico-watch');
-  const nodeSassJsonImporter = require('node-sass-json-importer');
   const autoprefixer = require('autoprefixer');
 
   const instance = task({
@@ -87,10 +86,6 @@ gulp.task('css', () => {
         includePaths: [
           './src/',
           './src/assets/css/',
-        ],
-        importer: [
-          // Add importer being able to deal with json files like colors, e.g.
-          nodeSassJsonImporter,
         ],
       },
       postcss: [

--- a/packages/estatico-sass/index.js
+++ b/packages/estatico-sass/index.js
@@ -40,6 +40,11 @@ const defaults = (env = {}) => {
   const autoprefixer = require('autoprefixer');
   const clean = require('postcss-clean');
   const filterStream = require('postcss-filter-stream');
+  const nodeSassJsonImporter = require('node-sass-json-importer');
+  const fs = require('fs');
+  const path = require('path');
+
+  const logger = new Logger('estatico-sass');
 
   return {
     src: null,
@@ -50,13 +55,39 @@ const defaults = (env = {}) => {
     plugins: {
       sass: {
         includePaths: null,
+        importer: [
+          nodeSassJsonImporter,
+
+          // Resolve CSS files
+          (url, file) => {
+            if (!/\.css$/.test(url)) {
+              return null;
+            }
+
+            const filePath = path.resolve(path.dirname(file), url);
+
+            if (!fs.existsSync(filePath)) {
+              logger.error({
+                message: `Import "${url}" not found`,
+                plugin: 'Custom CSS importer',
+              }, env.dev);
+
+              return null;
+            }
+
+            return {
+              file: url,
+              contents: fs.readFileSync(filePath, 'utf-8'),
+            };
+          },
+        ],
       },
       clone: env.ci,
       postcss: [
         autoprefixer(),
       ].concat(env.dev ? [] : filterStream(['**/*', '!**/*.min*'], clean())),
     },
-    logger: new Logger('estatico-sass'),
+    logger,
   };
 };
 

--- a/packages/estatico-sass/package.json
+++ b/packages/estatico-sass/package.json
@@ -23,6 +23,7 @@
     "gulp-sourcemaps": "^2.6.4",
     "joi": "^13.2.0",
     "lodash.merge": "^4.6.1",
+    "node-sass-json-importer": "^3.2.0",
     "postcss-clean": "^1.1.0",
     "postcss-filter-stream": "^0.0.6",
     "through2": "^2.0.3"


### PR DESCRIPTION
This will fix the `DEPRECATION WARNING Including .css files with @import is non-standard behaviour which will be removed in future versions of LibSass. Use a custom importer to maintain this behaviour. Check your implementations documentation on how to create a custom importer.`

Instead of using the external plugin mentioned in https://github.com/unic/estatico-nou/issues/45, I went for a solution where we don't have to add a `CSS:` prefix to the import.