### PR TITLE
fix(estatico-boilerplate): fix regex for css and html file watcher

### DIFF
--- a/packages/estatico-boilerplate/gulpfile.js
+++ b/packages/estatico-boilerplate/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('html', () => {
         srcBase: './',
         resolver: {
           hbs: {
-            match: /{{(?:>|#extend)[\s-]*["|']?([^"\s(]+).*?}}/g,
+            match: /{{(?:>|#extend)[\s-]*["|']?([^(?:"|')\s(]+).*?}}/g,
             resolve: (match /* , filePath */) => {
               if (!match[1]) {
                 return null;
@@ -218,7 +218,7 @@ gulp.task('css', () => {
         srcBase: './',
         resolver: {
           scss: {
-            match: /@import[\s-]*["|']?([^"\s(]+).*?/g,
+            match: /@import[\s-]*["|']?([^(?:"|')\s(]+).*?/g,
             resolve: (match, filePath) => {
               if (!match[1]) {
                 return null;

--- a/packages/estatico-handlebars/README.md
+++ b/packages/estatico-handlebars/README.md
@@ -52,7 +52,7 @@ gulp.task('html', () => {
         srcBase: './',
         resolver: {
           hbs: {
-            match: /{{(?:>|#extend)[\s-]*["|']?([^"\s(]+).*?}}/g,
+            match: /{{(?:>|#extend)[\s-]*["|']?([^(?:"|')\s(]+).*?}}/g,
             resolve: (match /* , filePath */) => {
               if (!match[1]) {
                 return null;

--- a/packages/estatico-sass/README.md
+++ b/packages/estatico-sass/README.md
@@ -46,7 +46,7 @@ gulp.task('css', () => {
         srcBase: './',
         resolver: {
           scss: {
-            match: /@import[\s-]*["|']?([^"\s(]+).*?/g,
+            match: /@import[\s-]*["|']?([^(?:"|')\s(]+).*?/g,
             resolve: (match, filePath) => {
               if (!match[1]) {
                 return null;


### PR DESCRIPTION
The previous regex did not work for single-quotes since we were looking for a "closing" double-quote.