### PR TITLE
Bugfix/add corejs version

### DIFF
--- a/packages/estatico-webpack/.babelrc.js
+++ b/packages/estatico-webpack/.babelrc.js
@@ -6,6 +6,7 @@ module.exports = {
     ['@babel/preset-env', {
       // Include polyfills when needed
       useBuiltIns: 'usage',
+      corejs: 3,
 
       // See browserslist file for config
       // targets: {},

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unic/estatico-webpack",
-  "version": "0.0.21",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unic/estatico-webpack",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/estatico-webpack/package.json
+++ b/packages/estatico-webpack/package.json
@@ -18,6 +18,7 @@
     "@unic/estatico-utils": "0.0.10",
     "babel-loader": "^8.0.4",
     "chalk": "^2.4.1",
+    "core-js": "^3.8.2",
     "expose-loader": "^0.7.5",
     "handlebars-loader": "^1.7.0",
     "joi": "^14.0.2",


### PR DESCRIPTION
Babel warns that a core-js version should be specified in babelrc